### PR TITLE
Convert to use compose watch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ CMD ["yarn", "dev"]
 ###################################################
 FROM base AS client-build
 COPY client/package.json client/yarn.lock ./
-RUN --mount=type=cache,id=yarn,target=/root/.yarn yarn install
+RUN --mount=type=cache,id=yarn,target=/usr/local/share/.cache/yarn \
+    yarn install
 COPY client/.eslintrc.cjs client/index.html client/vite.config.js ./
 COPY client/public ./public
 COPY client/src ./src
@@ -46,7 +47,8 @@ RUN yarn build
 ###################################################
 FROM base AS test
 COPY backend/package.json backend/yarn.lock ./
-RUN --mount=type=cache,id=yarn,target=/root/.yarn yarn install --frozen-lockfile
+RUN --mount=type=cache,id=yarn,target=/usr/local/share/.cache/yarn \
+    yarn install --frozen-lockfile
 COPY backend/spec ./spec
 COPY backend/src ./src
 RUN yarn test
@@ -63,7 +65,8 @@ RUN yarn test
 FROM base AS final
 ENV NODE_ENV=production
 COPY --from=test /usr/local/app/package.json /usr/local/app/yarn.lock ./
-RUN --mount=type=cache,id=yarn,target=/root/.yarn yarn install --production --frozen-lockfile
+RUN --mount=type=cache,id=yarn,target=/usr/local/share/.cache/yarn \
+    yarn install --production --frozen-lockfile
 COPY backend/src ./src
 COPY --from=client-build /usr/local/app/dist ./src/static
 EXPOSE 3000

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
     "format": "prettier -l --write \"**/*.js\"",
     "format-check": "prettier --check \"**/*.js\"",
     "test": "jest",
-    "dev": "yarn install && nodemon src/index.js"
+    "dev": "nodemon src/index.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "yarn install && vite --host=0.0.0.0",
+    "dev": "vite --host=0.0.0.0",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/client/src/components/ItemDisplay.jsx
+++ b/client/src/components/ItemDisplay.jsx
@@ -32,7 +32,7 @@ export function ItemDisplay({ item, onItemUpdate, onItemRemoval }) {
     return (
         <Container fluid className={`item ${item.completed && 'completed'}`}>
             <Row>
-                <Col xs={1} className="text-center">
+                <Col xs={2} className="text-center">
                     <Button
                         className="toggles"
                         size="sm"
@@ -54,10 +54,10 @@ export function ItemDisplay({ item, onItemUpdate, onItemRemoval }) {
                         />
                     </Button>
                 </Col>
-                <Col xs={10} className="name">
+                <Col xs={8} className="name">
                     {item.name}
                 </Col>
-                <Col xs={1} className="text-center remove">
+                <Col xs={2} className="text-center remove">
                     <Button
                         size="sm"
                         variant="link"

--- a/compose.yml
+++ b/compose.yml
@@ -50,10 +50,11 @@ services:
   # 
   # This service is the Node.js server that provides the API for the app.
   # When the container starts, it will use the image that results
-  # from building the Dockerfile, targeting the dev stage.
+  # from building the Dockerfile, targeting the backend-dev stage.
   #
-  # The code is mounted into the container, allowing the backend to be 
-  # automatically reloaded when code changes are made (thanks to nodemon).
+  # The Compose Watch configuration is used to automatically sync the code
+  # from the host machine to the container. This allows the server to be
+  # automatically reloaded when code changes are made.
   #
   # The environment variables configure the application to connect to the
   # database, which is also configured in this Compose file. We obviously
@@ -67,14 +68,19 @@ services:
   backend:
     build:
       context: ./
-      target: dev
-    volumes:
-      - ./backend:/usr/local/app
+      target: backend-dev
     environment:
       MYSQL_HOST: mysql
       MYSQL_USER: root
       MYSQL_PASSWORD: secret
       MYSQL_DB: todos
+    develop:
+      watch:
+        - path: ./backend/src
+          action: sync
+          target: /usr/local/app/src
+        - path: ./backend/package.json
+          action: rebuild
     labels:
       traefik.http.routers.backend.rule: Host(`localhost`) && PathPrefix(`/api`)
       traefik.http.services.backend.loadbalancer.server.port: 3000
@@ -86,8 +92,9 @@ services:
   # When the container starts, it will use the image that results from building
   # the Dockerfile, targeting the dev stage.
   #
-  # The code is mounted into the container, allowing the client to be automatically
-  # reloaded when code changes are made (thanks to vite).
+  # The Compose Watch configuration is used to automatically sync the code from
+  # the host machine to the container. This allows the client to be automatically
+  # reloaded when code changes are made.
   # 
   # The labels are used to configure Traefik (the reverse proxy) with the 
   # appropriate routing rules. In this case, all requests to localhost will be
@@ -96,9 +103,14 @@ services:
   client:
     build:
       context: ./
-      target: dev
-    volumes:
-      - ./client:/usr/local/app
+      target: client-dev
+    develop:
+      watch:
+        - path: ./client/src
+          action: sync
+          target: /usr/local/app/src
+        - path: ./client/package.json
+          action: rebuild
     labels:
       traefik.http.routers.client.rule: Host(`localhost`)
       traefik.http.services.client.loadbalancer.server.port: 5173


### PR DESCRIPTION
This PR converts the project to use Compose Watch. A few notable points...

- The Dockerfile introduces a few additional stages because we need to actually build the image with the source code in a dev-ready mode, rather than expecting the files to be present via the bind mounts
- The Compose file dropped all bind mounts and swapped for watch config
- Documentation (in Dockerfile, Compose file, and README) should all be updated

Feel free to clone, checkout the project, and validate it works for you. Thanks!