### PR TITLE
Fix yarn install error causing docker compose watch to fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ WORKDIR /usr/local/app
 ###################################################
 FROM base AS client-base
 COPY client/package.json client/yarn.lock ./
-RUN --mount=type=cache,id=yarn,target=/usr/local/share/.cache/yarn \
-    yarn install
+RUN yarn install --production --ignore-engines
 COPY client/.eslintrc.cjs client/index.html client/vite.config.js ./
 COPY client/public ./public
 COPY client/src ./src


### PR DESCRIPTION
The issue is when following the[ Docker Guides](https://docs.docker.com/guides/getting-started/develop-with-containers/#start-the-project) and running `docker compose watch` I get the following error:
![Screenshot 2024-07-13 at 12 40 31 PM](https://github.com/user-attachments/assets/91a05801-7695-480f-a3f4-f327f2b0e52e)

I stumbled on this fix and it resolved the issue for me:
https://github.com/docker/getting-started/issues/381#issuecomment-1657000398

![Screenshot 2024-07-13 at 12 40 52 PM](https://github.com/user-attachments/assets/5713f5d5-edf3-4bb9-bd5f-d71440f7f790)
