### PR TITLE
bump traefik version 3.4 -> 3.6

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,7 +38,7 @@ services:
   # We also expose port 80 to connect to the proxy from the host machine.
   ###################################################
   proxy:
-    image: traefik:v3.4
+    image: traefik:v3.6
     command: --providers.docker
     ports:
       - 80:80


### PR DESCRIPTION
fixes https://github.com/docker/getting-started-todo-app/issues/74

currently running `docker compose up --watch` shows error: 
```
Failed to retrieve information of the docker client and server host error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version" providerName=docker
```
and requests to `http://localhost/` get 404 response.

upgrading to traefik 3.6 fixes the issue