### PR TITLE
fix(docker): make sqlite3 native build explicit and fail fast

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,27 @@ RUN npm run build
 # in any shipped image layer.
 ###################################################
 FROM base AS sqlite3-build
+# Explicit native-addon build toolchain. Pinned here rather than relying on
+# whatever happens to ship in the upstream node:22 image, so this stage
+# stays reproducible even if the base image's bundled toolchain changes.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        make \
+        g++ \
+    && rm -rf /var/lib/apt/lists/*
 COPY backend/package.json backend/package-lock.json ./
 COPY .npmrc .
+# ignore-scripts=true (see .npmrc) skips sqlite3's postinstall step, which
+# is what would normally compile its native binding. We rebuild it
+# explicitly here by invoking node-gyp directly (bypassing npm's script
+# runner entirely, so the project-level ignore-scripts=true has no effect
+# on this specific command).
 RUN npm ci && cd node_modules/sqlite3 && ../.bin/node-gyp rebuild
+# Fail the build here, with a clear message, if the compiled binary isn't
+# where the sqlite3 package expects it — instead of deferring an opaque
+# "Could not locate the bindings file" failure to test time.
+RUN test -f node_modules/sqlite3/build/Release/node_sqlite3.node \
+    || (echo "ERROR: sqlite3 native binding was not produced by node-gyp rebuild" && exit 1)
 
 ###################################################
 # Stage: backend-base


### PR DESCRIPTION
## Summary

This PR improves the `sqlite3-build` stage in the Dockerfile by making the native addon build process explicit and adding an early verification step.

### Changes

- Install the native build toolchain (`python3`, `make`, `g++`) explicitly in the `sqlite3-build` stage instead of relying on the upstream `node:22` image.
- Continue rebuilding the `sqlite3` native binding using `node-gyp`.
- Add a build-time check that verifies `node_modules/sqlite3/build/Release/node_sqlite3.node` exists.
- Fail the Docker build with a clear error if the native binary is not produced.

## Why

Previously, the Docker build relied on the base image implicitly providing the required compilation tools. If the native binding failed to build, the error only appeared later during the test stage as:
